### PR TITLE
No trailers after last episode credits

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Google Chrome Extension for a couple of Netflix tweaks:
 - Remove Hearing Impaired/CC parts (the stuff in [square brackets] from subtitles
 - Remove ♪lyrics♪ from subtitles
 - Keep the credits rolling in full screen
+- Stop post-credits playback of a trailer after final episode credits
 
 <br/>
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Google Chrome Extension for a couple of Netflix tweaks:
 - Remove Hearing Impaired/CC parts (the stuff in [square brackets] from subtitles
 - Remove ♪lyrics♪ from subtitles
 - Keep the credits rolling in full screen
-- Stop post-credits playback of a trailer after final episode credits
+- Avoid playback of a trailer after final episode credits
 
 <br/>
 

--- a/options.html
+++ b/options.html
@@ -36,6 +36,10 @@
         <input type="checkbox" id="postplayFullscreen" />
         <label for="postplayFullscreen">Keep the credits rolling in full screen</label>
     </div>
+    <div>
+        <input type="checkbox" id="avoidPostCreditsTrailer" />
+        <label for="avoidPostCreditsTrailer">Don't allow autoplay of random trailer after final episode credits.</label>
+    </div>
 </div>
 </body>
 </html>

--- a/options.js
+++ b/options.js
@@ -1,7 +1,7 @@
 
 (function() {
 
-    const optionIds = ['removeCCSubs', 'removeMusicSubs', 'postplayFullscreen'];
+    const optionIds = ['removeCCSubs', 'removeMusicSubs', 'postplayFullscreen', 'avoidPostCreditsTrailer'];
 
 
     function load() {

--- a/script.js
+++ b/script.js
@@ -47,12 +47,24 @@
                 });
             }
         }
-
+        
         if (options['postplayFullscreen']) {
             const postplay = document.querySelector('.postplay video');
             if (postplay) {
                 postplay.click();
                 console.log(extensionName + ' - hiding postplay (promo instead of credits)');
+            }
+        }
+        
+        if (options['avoidPostCreditsTrailer']) {
+            const countDown = document.querySelector(".PromotedVideo");
+            if(countDown){
+                const postplay = document.querySelector('.postplay video');
+                const backToBrowse = document.querySelector('a.BackToBrowse');
+                if(!postplay && backToBrowse){
+                    backToBrowse.click();
+                    console.log(extensionName + ' - stopping trailer autoplay (trailer after final credits)');
+                }
             }
         }
     }

--- a/script.js
+++ b/script.js
@@ -3,7 +3,7 @@
     const extensionName = 'Netflix Tweaks extension';
     console.log(extensionName + ' - loaded');
 
-    const optionIds = ['removeCCSubs', 'removeMusicSubs', 'postplayFullscreen'];
+    const optionIds = ['removeCCSubs', 'removeMusicSubs', 'postplayFullscreen', 'avoidPostCreditsTrailer'];
     const options = {};
 
     chrome.storage.local.get(optionIds, result => {


### PR DESCRIPTION
This is quite similar to "postplayFullscreen" feature, but basically when you're reaching end of the video file netflix will try one again to show you a random trailer in 5 seconds. The only way to avoid it is to click the BackToBrowse button in the top left. This option does that. See the attached video if you don't understand.
I dunno, maybe it makes more sense navigating to https://www.netflix.com/browse/my-list instead of clicking BackToBrowse?
In any case, default Netflix behaviour of bombarding the user with some loud trailer after finishing a series was not something I liked.

P.S. I'm okay if you don't want to merge this, for any reason.
I learned from your code how to do this stuff via Tampermonkey, so basically I can script whatever I want now. Thanks!

https://user-images.githubusercontent.com/21346282/113460668-2ece4100-9422-11eb-8ae5-43f49adb8d4f.mp4

